### PR TITLE
Fix status bar item preventing plugin from being enabled

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -66,6 +66,10 @@ export default class HemingwayModePlugin extends Plugin {
     await this.loadSettings();
     this.buildKeyMapScope(this.settings.allowBackspace);
     this.keymapInstalled = false;
+
+    this.statusBar = this.addStatusBarItem();
+    this.statusBar.addClass("hemingway-mode-status");
+
     await this.updateStatus(true);
 
     this.registerInterval(
@@ -80,10 +84,6 @@ export default class HemingwayModePlugin extends Plugin {
         }
       }, 500)
     );
-
-    const statusBarItem = this.addStatusBarItem();
-    this.statusBar = statusBarItem.createSpan();
-    this.statusBar.addClass("hemingway-mode-status");
   }
 
   async onunload() {
@@ -156,12 +156,20 @@ export default class HemingwayModePlugin extends Plugin {
       return;
     }
 
-    this.statusBar.setText(this.settings.showStatusBar && this.settings.enabled ? this.settings.statusBarText : "");
+    this.statusBar.setText(this.settings.statusBarText);
 
     if (this.settings.enabled) {
+      if (this.settings.showStatusBar) {
+        this.statusBar.show();
+      }
+
       await this.installHemingwayKeymap();
       await this.setupView();
     } else {
+      if (this.settings.showStatusBar) {
+        this.statusBar.hide();
+      }
+
       await this.uninstallHemingwayKeymap();
       await this.restoreView();
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "isolatedModules": true,
-	"strictNullChecks": true,
+    "strictNullChecks": true,
     "lib": [
       "DOM",
       "ES5",


### PR DESCRIPTION
Hey 👋 thanks for the great plugin! Unfortunately, I received the error `Plugin failure: hemingway-mode TypeError: Cannot read properties of undefined (reading 'setText')` which prevented the plugin from being enabled in Obsidian. I noticed that the issue is caused because in `onload` the `updateStatus` function, which uses `this.statusBar` is called before setting `this.statusBar`. I changed the order to resolve the issue.

Furthermore, I noticed that the plugin adds an empty space to the status bar, when `Hemingway Mode` is disabled because the status bar item is not hidden, but its text is just set to an empty string. This means that Obsidian still adds a margin in its place. I changed it to actually use `show` and `hide` on the status bar item. Please let me know if you like this change. Otherwise we can roll it back.

I am looking forward to your feedback and possible merge of this PR. Thank you so much for developing and maintaining the plugin!